### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+**/CMakeLists.txt @pfultz2


### PR DESCRIPTION
This project is a fork of the half library with cmake/packaging scripts added for ROCm. The source code is managed by upstream, we only make changes to the packaging scripts.

Let's just have a CODEOWNER for the packaging files that we maintain.