### PR TITLE
Overload `std::isfinite` to omit implicit float conversion

### DIFF
--- a/include/half.hpp
+++ b/include/half.hpp
@@ -3035,6 +3035,11 @@ namespace std
 		static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0001); }
 	};
 
+	/// Overload `std::isfinite` to omit implicit float conversion
+    inline bool isfinite(const half_float::half& h) {
+        return half_float::isfinite(h);
+    }
+
 #if HALF_ENABLE_CPP11_HASH
 	/// Hash function for half-precision floats.
 	/// This is only defined if C++11 `std::hash` is supported and enabled.


### PR DESCRIPTION
This produces faster code for libstdc++ and fixes compilation with libc++.

Closes https://github.com/ROCm/half/issues/16